### PR TITLE
Refactor SongPlayer layout and responsive styles

### DIFF
--- a/MusicSalesApp/Components/Pages/SongPlayer.razor
+++ b/MusicSalesApp/Components/Pages/SongPlayer.razor
@@ -5,7 +5,7 @@
 
 <PageTitle>@GetDisplayTitle()</PageTitle>
 
-<div class="spotify-container">
+<div class="song-player-container">
     @if (_loading)
     {
         <div class="loading-state">
@@ -142,99 +142,99 @@
             </div>
         </div>        
 
-    <!-- Hidden Audio Element -->
-    <audio @ref="_audioElement"
-           src="@_streamUrl"
-           preload="auto"
-           style="display:none;"></audio>
+        <!-- Hidden Audio Element -->
+        <audio @ref="_audioElement"
+               src="@_streamUrl"
+               preload="auto"
+               style="display:none;"></audio>
 
-    <!-- Bottom Player Bar -->
-    <div class="player-bar mt-auto">
-        <div class="controls-wrapper">
-            <span class="time-spacer"></span>
-            <div class="player-controls-row">
-                <div class="player-controls">
-                    <button class="control-button @(_shuffleEnabled ? "active" : "")" @onclick="ToggleShuffle" title="Shuffle">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="control-icon">
-                            <path d="M10.59 9.17L5.41 4 4 5.41l5.17 5.17 1.42-1.41zM14.5 4l2.04 2.04L4 18.59 5.41 20 17.96 7.46 20 9.5V4h-5.5zm.33 9.41l-1.41 1.41 3.13 3.13L14.5 20H20v-5.5l-2.04 2.04-3.13-3.13z" />
-                        </svg>
-                    </button>
-                    <button class="control-button" title="Previous">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="control-icon">
-                            <path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" />
-                        </svg>
-                    </button>
-                    <button class="play-button-small" @onclick="TogglePlay" title="@(_isPlaying ? "Pause" : "Play")">
-                        @if (_isPlaying)
-                        {
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="play-icon-small">
-                                <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
-                            </svg>
-                        }
-                        else
-                        {
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="play-icon-small">
-                                <path d="M8 5v14l11-7z" />
-                            </svg>
-                        }
-                    </button>
-                    <button class="control-button" title="Next">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="control-icon">
-                            <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />
-                        </svg>
-                    </button>
-                    <button class="control-button @(_repeatEnabled ? "active" : "")" @onclick="ToggleRepeat" title="Repeat">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="control-icon">
-                            <path d="M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4z" />
-                        </svg>
-                    </button>
-                </div>
-                <div class="volume-controls">
-                    <button class="control-button" @onclick="ToggleMute" title="@(_isMuted ? "Unmute" : "Mute")">
-                        @if (_isMuted || GetDisplayVolume() == 0)
-                        {
-                            <!-- Muted icon -->
+        <!-- Bottom Player Bar -->
+        <div class="player-bar">
+            <div class="controls-wrapper">
+                <span class="time-spacer"></span>
+                <div class="player-controls-row">
+                    <div class="player-controls">
+                        <button class="control-button @(_shuffleEnabled ? "active" : "")" @onclick="ToggleShuffle" title="Shuffle">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="control-icon">
-                                <path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z" />
+                                <path d="M10.59 9.17L5.41 4 4 5.41l5.17 5.17 1.42-1.41zM14.5 4l2.04 2.04L4 18.59 5.41 20 17.96 7.46 20 9.5V4h-5.5zm.33 9.41l-1.41 1.41 3.13 3.13L14.5 20H20v-5.5l-2.04 2.04-3.13-3.13z" />
                             </svg>
-                        }
-                        else if (GetDisplayVolume() < 0.5)
-                        {
-                            <!-- Low volume icon -->
+                        </button>
+                        <button class="control-button" title="Previous">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="control-icon">
-                                <path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z" />
+                                <path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" />
                             </svg>
-                        }
-                        else
-                        {
-                            <!-- High volume icon -->
+                        </button>
+                        <button class="play-button-small" @onclick="TogglePlay" title="@(_isPlaying ? "Pause" : "Play")">
+                            @if (_isPlaying)
+                            {
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="play-icon-small">
+                                    <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
+                                </svg>
+                            }
+                            else
+                            {
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="play-icon-small">
+                                    <path d="M8 5v14l11-7z" />
+                                </svg>
+                            }
+                        </button>
+                        <button class="control-button" title="Next">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="control-icon">
-                                <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" />
+                                <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />
                             </svg>
-                        }
-                    </button>
-                    <div @ref="_volumeBarContainer" class="volume-bar-container" @onclick="OnVolumeBarClick">
-                        <div class="volume-bar" style="width: @(GetDisplayVolume() * 100)%;">
-                            <div class="volume-thumb"></div>
+                        </button>
+                        <button class="control-button @(_repeatEnabled ? "active" : "")" @onclick="ToggleRepeat" title="Repeat">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="control-icon">
+                                <path d="M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4z" />
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="volume-controls">
+                        <button class="control-button" @onclick="ToggleMute" title="@(_isMuted ? "Unmute" : "Mute")">
+                            @if (_isMuted || GetDisplayVolume() == 0)
+                            {
+                                <!-- Muted icon -->
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="control-icon">
+                                    <path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z" />
+                                </svg>
+                            }
+                            else if (GetDisplayVolume() < 0.5)
+                            {
+                                <!-- Low volume icon -->
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="control-icon">
+                                    <path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z" />
+                                </svg>
+                            }
+                            else
+                            {
+                                <!-- High volume icon -->
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="control-icon">
+                                    <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" />
+                                </svg>
+                            }
+                        </button>
+                        <div @ref="_volumeBarContainer" class="volume-bar-container" @onclick="OnVolumeBarClick">
+                            <div class="volume-bar" style="width: @(GetDisplayVolume() * 100)%;">
+                                <div class="volume-thumb"></div>
+                            </div>
                         </div>
                     </div>
                 </div>
+                <span class="time-spacer"></span>
             </div>
-            <span class="time-spacer"></span>
-        </div>
-        <div class="progress-container">
-            <span class="time-display">@FormatTime(_currentTime)</span>
-            <div @ref="_progressBarContainer" class="progress-bar-container @(IsProgressBarRestricted() ? "restricted" : "")" @onclick="OnProgressBarClick">
-                <div class="progress-bar" style="width: @(GetProgressBarWidth())%;">
-                    <div class="progress-thumb"></div>
+            <div class="progress-container">
+                <span class="time-display">@FormatTime(_currentTime)</span>
+                <div @ref="_progressBarContainer" class="progress-bar-container @(IsProgressBarRestricted() ? "restricted" : "")" @onclick="OnProgressBarClick">
+                    <div class="progress-bar" style="width: @(GetProgressBarWidth())%;">
+                        <div class="progress-thumb"></div>
+                    </div>
+                    @if (IsProgressBarRestricted())
+                    {
+                        <div class="progress-limit-marker" style="left: @(GetPreviewLimitPercentage())%;"></div>
+                    }
                 </div>
-                @if (IsProgressBarRestricted())
-                {
-                    <div class="progress-limit-marker" style="left: @(GetPreviewLimitPercentage())%;"></div>
-                }
+                <span class="time-display">@FormatTime(GetDisplayDuration())</span>
             </div>
-            <span class="time-display">@FormatTime(GetDisplayDuration())</span>
         </div>
-    </div>
     }
 </div>

--- a/MusicSalesApp/Components/Pages/SongPlayer.razor.css
+++ b/MusicSalesApp/Components/Pages/SongPlayer.razor.css
@@ -14,7 +14,22 @@
     min-height: 200px;
 }
 
+/* Song Player Container - Grid Layout (similar to AlbumPlayer) */
+.song-player-container {
+    display: grid;
+    grid-template-rows: 1fr 88px;
+    grid-template-columns: 100%;
+    height: calc(100vh - 66px);
+    width: 100%;
+    overflow: hidden;
+    color: #fff;
+}
 
+/* Song Header Section */
+.song-header {
+    padding: 24px;
+    overflow-y: auto;
+}
 
 .album-art-placeholder {
     width: 192px;
@@ -34,7 +49,7 @@
 .song-label { font-size: 14px; font-weight: 700; text-transform: uppercase; }
 
 /* Action Controls Section */
-.action-controls { display: flex; align-items: center; gap: 24px; padding: 24px 0; }
+.action-controls { display: flex; align-items: center; gap: 24px; padding: 24px 0; position: relative; }
 
 .play-button-large {
     width: 56px; height: 56px; border-radius: 50%; background-color: #1db954; border: none; cursor: pointer;
@@ -46,10 +61,18 @@
 
 .play-icon { width: 28px; height: 28px; color: #000; margin-left: 2px; }
 
-
-
-/* Desktop layout - account for sidebar and article padding */
-/* Responsive rules moved to global breakpoint files in wwwroot */
+/* Player Bar - Fixed to bottom via grid */
+.player-bar {
+    background: linear-gradient(to top, #181818 0%, #282828 100%);
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 16px 24px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    z-index: 1000;
+    box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3);
+}
 
 .controls-wrapper { display: flex; align-items: center; gap: 8px; width: 100%; max-width: 600px; margin-bottom: 8px; }
 .time-spacer { min-width: 40px; }
@@ -83,10 +106,7 @@
 .volume-thumb { position: absolute; right: -6px; top: 50%; transform: translateY(-50%); width: 12px; height: 12px; background-color: #fff; border-radius: 50%; opacity: 0; transition: opacity 0.2s ease; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5); }
 .volume-bar-container:hover .volume-thumb { opacity: 1; }
 
-/* Responsive rules moved to global breakpoint files in wwwroot */
-
 /* Owned Badge */
-
 .owned-badge { position: absolute; bottom: 8px; right: 8px; background-color: #1db954; border-radius: 50%; width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3); }
 .owned-badge svg { width: 20px; height: 20px; color: #fff; }
 
@@ -110,8 +130,6 @@
 }
 
 /* Add to Cart Button on SongPlayer */
-.action-controls { position: relative; }
-
 .cart-button-wrapper{ position:relative; display:inline-block; }
 .cart-button-large {
     display: flex;
@@ -128,22 +146,22 @@
     transition: all 0.2s ease;
 }
 
-    .cart-button-large:hover {
-        border-color: #fff;
-        color: #fff;
-        transform: scale(1.02);
-    }
+.cart-button-large:hover {
+    border-color: #fff;
+    color: #fff;
+    transform: scale(1.02);
+}
 
-    .cart-button-large.in-cart {
-        background-color: #1db954;
-        border-color: #1db954;
-        color: #fff;
-    }
+.cart-button-large.in-cart {
+    background-color: #1db954;
+    border-color: #1db954;
+    color: #fff;
+}
 
-        .cart-button-large.in-cart:hover {
-            background-color: #1ed760;
-            border-color: #1ed760;
-        }
+.cart-button-large.in-cart:hover {
+    background-color: #1ed760;
+    border-color: #1ed760;
+}
 
 .cart-icon-large {
     width: 20px;
@@ -171,8 +189,8 @@
 /* Music Note Float Animation for Song Player */
 .music-note-float-player {
     position: absolute;
-    left: 50%; /* center horizontally over button */
-    top: 0; /* start at top edge of button */
+    left: 50%;
+    top: 0;
     color: #1db954;
     font-size: 28px;
     pointer-events: none;

--- a/MusicSalesApp/wwwroot/lg_app.css
+++ b/MusicSalesApp/wwwroot/lg_app.css
@@ -6,46 +6,19 @@
         height: calc(100vh - 9rem);
     }
 
-    /* AlbumPlayer - Container adjustments 
-    .spotify-container {
-        padding-bottom: 180px;
+    /* SongPlayer - Container adjustments for large screens */
+    .song-player-container {
+        grid-template-rows: 1fr 88px;
     }
-*/
-    /* AlbumPlayer - Track List 
-    .track-list-container {
-        margin: -62px 0;
-        padding-bottom: 10px;
-        max-height: calc(100vh - 591px);
-        overflow-y: auto;
-        overflow-x: hidden;
-    }*/
 
-    /* AlbumPlayer - Player Bar 
-    .player-bar {
-        position: fixed;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        background: linear-gradient(to top, #181818 0%, #282828 100%);
-        border-top: 1px solid rgba(255, 255, 255, 0.1);
-        padding: 16px 24px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+    .song-player-container .song-header {
+        padding: 24px;
+    }
+
+    .song-player-container .player-bar {
+        padding: 14px 24px;
         gap: 8px;
-        z-index: 1000;
-        box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3);
-    }*/
-
-    /* Song Header Section 
-    .song-header {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 24px;
-        padding: 24px 0;
-        margin-bottom: 24px;
-    }*/
+    }
 
     .album-art {
         width: 235px;
@@ -68,45 +41,38 @@
         padding: 0;
     }
 
-    /*
-    .track-list {
-        width: 100%;
-        border-collapse: collapse;
-        color: #b3b3b3;
-    }*/
+    .track-list thead {
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
 
-        .track-list thead {
-            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    .track-list th {
+        font-size: 12px;
+        font-weight: 400;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        padding: 8px 16px;
+        text-align: left;
+    }
+
+        .track-list th.track-number {
+            width: 50px;
+            text-align: center;
         }
 
-        .track-list th {
-            font-size: 12px;
-            font-weight: 400;
-            text-transform: uppercase;
-            letter-spacing: 0.1em;
-            padding: 8px 16px;
-            text-align: left;
+        .track-list th.track-image {
+            width: 60px;
+            padding-left: 0;
+            padding-right: 0;
         }
 
-            .track-list th.track-number {
-                width: 50px;
-                text-align: center;
-            }
+        .track-list th.track-duration {
+            width: 80px;
+            text-align: right;
+        }
 
-            .track-list th.track-image {
-                width: 60px;
-                padding-left: 0;
-                padding-right: 0;
-            }
-
-            .track-list th.track-duration {
-                width: 80px;
-                text-align: right;
-            }
-
-            .track-list th.track-actions {
-                width: 50px;
-            }
+        .track-list th.track-actions {
+            width: 50px;
+        }
 
     .track-row {
         border-radius: 4px;

--- a/MusicSalesApp/wwwroot/md_app.css
+++ b/MusicSalesApp/wwwroot/md_app.css
@@ -6,36 +6,19 @@
         height: calc(100vh - 8rem);
     }
 
-    /* AlbumPlayer - Container adjustments 
-    .spotify-container {
-        padding-bottom: 170px;
-    }*/
+    /* SongPlayer - Container adjustments for medium screens */
+    .song-player-container {
+        grid-template-rows: 1fr 85px;
+    }
 
-    /* AlbumPlayer - Track List 
-    .track-list-container {
-        margin: 24px 0;
-        padding-bottom: 20px;
-        max-height: calc(100vh - 600px);
-        overflow-y: auto;
-        overflow-x: hidden;
-    }*/
+    .song-player-container .song-header {
+        padding: 20px;
+    }
 
-    /* AlbumPlayer - Player Bar 
-    .player-bar {
-        position: fixed;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        background: linear-gradient(to top, #181818 0%, #282828 100%);
-        border-top: 1px solid rgba(255, 255, 255, 0.1);
-        padding: 14px 20px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 8px;
-        z-index: 1000;
-        box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3);
-    }*/
+    .song-player-container .player-bar {
+        padding: 12px 20px;
+        gap: 6px;
+    }
 
     .title-container {
         display: flex;
@@ -50,44 +33,38 @@
         border-radius: 4px;
     }
 
-   /*.track-list {
-        width: 100%;
-        border-collapse: collapse;
-        color: #b3b3b3;
-    }*/ 
+    .track-list thead {
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
 
-        .track-list thead {
-            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    .track-list th {
+        font-size: 12px;
+        font-weight: 400;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        padding: 8px 16px;
+        text-align: left;
+    }
+
+        .track-list th.track-number {
+            width: 50px;
+            text-align: center;
         }
 
-        .track-list th {
-            font-size: 12px;
-            font-weight: 400;
-            text-transform: uppercase;
-            letter-spacing: 0.1em;
-            padding: 8px 16px;
-            text-align: left;
+        .track-list th.track-image {
+            width: 60px;
+            padding-left: 0;
+            padding-right: 0;
         }
 
-            .track-list th.track-number {
-                width: 50px;
-                text-align: center;
-            }
+        .track-list th.track-duration {
+            width: 80px;
+            text-align: right;
+        }
 
-            .track-list th.track-image {
-                width: 60px;
-                padding-left: 0;
-                padding-right: 0;
-            }
-
-            .track-list th.track-duration {
-                width: 80px;
-                text-align: right;
-            }
-
-            .track-list th.track-actions {
-                width: 50px;
-            }
+        .track-list th.track-actions {
+            width: 50px;
+        }
 
     .track-row {
         border-radius: 4px;

--- a/MusicSalesApp/wwwroot/sm_app.css
+++ b/MusicSalesApp/wwwroot/sm_app.css
@@ -6,36 +6,19 @@
         height: calc(100vh - 7rem);
     }
 
-    /* AlbumPlayer - Container adjustments 
-    .spotify-container {
-        padding-bottom: 160px;
-    }*/
+    /* SongPlayer - Container adjustments for small screens */
+    .song-player-container {
+        grid-template-rows: 1fr 80px;
+    }
 
-    /* AlbumPlayer - Track List 
-    .track-list-container {
-        margin: 24px 0;
-        padding-bottom: 20px;
-        max-height: calc(100vh - 620px);
-        overflow-y: auto;
-        overflow-x: hidden;
-    }*/
+    .song-player-container .song-header {
+        padding: 16px;
+    }
 
-    /* AlbumPlayer - Player Bar 
-    .player-bar {
-        position: fixed;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        background: linear-gradient(to top, #181818 0%, #282828 100%);
-        border-top: 1px solid rgba(255, 255, 255, 0.1);
-        padding: 12px 16px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+    .song-player-container .player-bar {
+        padding: 10px 16px;
         gap: 6px;
-        z-index: 1000;
-        box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3);
-    }*/
+    }
 
     /* SongPlayer mobile adjustments */
     .song-title {
@@ -48,16 +31,6 @@
         box-shadow: 0 4px 60px rgba(0, 0, 0, 0.5);
         border-radius: 4px;
     }
-
-    /* Song Header Section 
-    .song-header {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 24px;
-        padding: 24px 0;
-        margin-bottom: 24px;
-    }*/
 
     .time-spacer { min-width: 0; display: none; }
     .controls-wrapper { gap: 2px; margin-bottom: 4px; }
@@ -74,6 +47,28 @@
     .action-controls { flex-wrap: wrap; gap: 16px; }
     .cart-button-large { padding: 10px 20px; font-size: 13px; }
     .cart-icon-large { width: 18px; height: 18px; }
+
+    /* SongPlayer - Player controls compact layout */
+    .song-player-container .controls-wrapper {
+        gap: 2px;
+        margin-bottom: 4px;
+        max-width: 100%;
+    }
+
+    .song-player-container .time-spacer {
+        display: none;
+        min-width: 0;
+    }
+
+    .song-player-container .player-controls-row {
+        gap: 4px;
+        width: 100%;
+    }
+
+    .song-player-container .progress-container {
+        gap: 4px;
+        max-width: 100%;
+    }
 
     /* MusicLibrary small adjustments */
     .music-cards-grid {
@@ -283,6 +278,16 @@
 
 /* Landscape Mobile Optimization - for devices with limited viewport height */
 @media (max-width: 1200px) and (max-height: 600px) and (orientation: landscape) {
+    /* SongPlayer - Landscape adjustments */
+    .song-player-container {
+        grid-template-rows: 1fr 70px;
+    }
+
+    .song-player-container .player-bar {
+        padding: 6px 12px;
+        gap: 2px;
+    }
+
     /* MusicLibrary - Reduce grid gaps and card spacing in landscape */
     .music-cards-grid {
         gap: 12px;

--- a/MusicSalesApp/wwwroot/xl_app.css
+++ b/MusicSalesApp/wwwroot/xl_app.css
@@ -6,45 +6,19 @@
         height: calc(100vh - 10rem);
     }
 
-    /* AlbumPlayer - Container adjustments 
-    .spotify-container {
-        padding-bottom: 180px;
-    }*/
+    /* SongPlayer - Container adjustments for extra large screens */
+    .song-player-container {
+        grid-template-rows: 1fr 88px;
+    }
 
-    /* AlbumPlayer - Track List 
-    .track-list-container {
-        margin: 24px 0;
-        padding-bottom: 20px;
-        max-height: calc(100vh - 580px);
-        overflow-y: auto;
-        overflow-x: hidden;
-    }*/
+    .song-player-container .song-header {
+        padding: 24px;
+    }
 
-    /* AlbumPlayer - Player Bar 
-    .player-bar {
-        position: fixed;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        background: linear-gradient(to top, #181818 0%, #282828 100%);
-        border-top: 1px solid rgba(255, 255, 255, 0.1);
+    .song-player-container .player-bar {
         padding: 16px 24px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
         gap: 8px;
-        z-index: 1000;
-        box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3);
-    }*/
-
-    /* Song Header Section 
-    .song-header {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 4px;
-        padding: 4px 0;
-    }*/
+    }
 
     .album-art {
         width: 250px;

--- a/MusicSalesApp/wwwroot/xs_app.css
+++ b/MusicSalesApp/wwwroot/xs_app.css
@@ -6,36 +6,19 @@
         height: calc(100vh - 6rem);
     }
 
-    /* AlbumPlayer - Container adjustments 
-    .spotify-container {
-        padding-bottom: 140px;
-    }*/
+    /* SongPlayer - Container adjustments for extra small screens */
+    .song-player-container {
+        grid-template-rows: 1fr 80px;
+    }
 
-    /* AlbumPlayer - Track List 
-    .track-list-container {
-        margin: 24px 0;
-        padding-bottom: 20px;
-        max-height: calc(100vh - 640px);
-        overflow-y: auto;
-        overflow-x: hidden;
-    }*/
+    .song-player-container .song-header {
+        padding: 16px;
+    }
 
-    /* AlbumPlayer - Player Bar 
-    .player-bar {
-        position: fixed;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        background: linear-gradient(to top, #181818 0%, #282828 100%);
-        border-top: 1px solid rgba(255, 255, 255, 0.1);
+    .song-player-container .player-bar {
         padding: 8px 12px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
         gap: 4px;
-        z-index: 1000;
-        box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.3);
-    }*/
+    }
 
     /* SongPlayer extra small adjustments */
     .song-title { font-size: 24px; }
@@ -250,5 +233,79 @@
         width: 10px;
         height: 10px;
         fill: currentColor;
+    }
+
+    /* SongPlayer - Player controls compact layout */
+    .song-player-container .controls-wrapper {
+        gap: 2px;
+        margin-bottom: 4px;
+        max-width: 100%;
+    }
+
+    .song-player-container .time-spacer {
+        display: none;
+        min-width: 0;
+    }
+
+    .song-player-container .player-controls-row {
+        gap: 4px;
+        width: 100%;
+    }
+
+    .song-player-container .player-controls {
+        gap: 2px;
+    }
+
+    .song-player-container .volume-controls {
+        gap: 4px;
+    }
+
+    .song-player-container .control-button {
+        width: 28px;
+        height: 28px;
+    }
+
+    .song-player-container .control-icon {
+        width: 14px;
+        height: 14px;
+    }
+
+    .song-player-container .play-button-small {
+        width: 28px;
+        height: 28px;
+    }
+
+    .song-player-container .play-icon-small {
+        width: 14px;
+        height: 14px;
+    }
+
+    .song-player-container .progress-container {
+        gap: 4px;
+        max-width: 100%;
+    }
+
+    .song-player-container .time-display {
+        min-width: 28px;
+        font-size: 10px;
+    }
+
+    .song-player-container .volume-bar-container {
+        width: 50px;
+    }
+
+    .song-player-container .action-controls {
+        flex-wrap: wrap;
+        gap: 12px;
+    }
+
+    .song-player-container .cart-button-large {
+        padding: 8px 16px;
+        font-size: 12px;
+    }
+
+    .song-player-container .cart-icon-large {
+        width: 16px;
+        height: 16px;
     }
 }


### PR DESCRIPTION
Redesigned SongPlayer to use a grid-based `.song-player-container` layout, replacing the old container and fixed player bar. Updated markup for clarity and maintainability. Overhauled CSS for improved alignment, spacing, and responsiveness. Responsive CSS files now support SongPlayer across all breakpoints, with compact controls for mobile and landscape. Removed obsolete AlbumPlayer styles. Minor button and cart style improvements. No changes to player functionality.